### PR TITLE
Add kvm on debian

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -7,6 +7,15 @@
     install_recommends: False
   with_items: [ 'libvirt-bin', 'netcat-openbsd', 'gawk', 'qemu-system', 'pm-utils', 'ebtables' ]
 
+- name: Install KVM-related packages for debian
+  apt:
+  apt:
+    name: '{{ item }}'
+    state: 'latest'
+    install_recommends: False
+  with_items: [ 'qemu-kvm' ]
+  when: ansible_os_family == 'Debian'
+
 - name: Add administrators to libvirt group
   user:
     name: '{{ item }}'

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -5,16 +5,7 @@
     name: '{{ item }}'
     state: 'latest'
     install_recommends: False
-  with_items: [ 'libvirt-bin', 'netcat-openbsd', 'gawk', 'qemu-system', 'pm-utils', 'ebtables' ]
-
-- name: Install KVM-related packages for debian
-  apt:
-  apt:
-    name: '{{ item }}'
-    state: 'latest'
-    install_recommends: False
-  with_items: [ 'qemu-kvm' ]
-  when: ansible_os_family == 'Debian'
+  with_items: [ 'libvirt-bin', 'netcat-openbsd', 'gawk', 'qemu-system', 'pm-utils', 'ebtables', 'qemu-kvm' ]
 
 - name: Add administrators to libvirt group
   user:


### PR DESCRIPTION
Hi, you mentioned in chat that qemu-kvm is not installed automatically because the package name is different on Ubuntu.
I don't run ubuntu, but mint, which should be ubuntu based. There is also a qemu-kvm package.
So, what version of ubuntu are you running?