### PR TITLE
Install qemu-utils package.

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -5,7 +5,7 @@
     name: '{{ item }}'
     state: 'latest'
     install_recommends: False
-  with_items: [ 'libvirt-bin', 'netcat-openbsd', 'gawk', 'qemu-system', 'pm-utils', 'ebtables', 'qemu-kvm' ]
+  with_items: [ 'libvirt-bin', 'netcat-openbsd', 'gawk', 'qemu-system', 'qemu-utils', 'pm-utils', 'ebtables', 'qemu-kvm' ]
 
 - name: Add administrators to libvirt group
   user:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -5,7 +5,15 @@
     name: '{{ item }}'
     state: 'latest'
     install_recommends: False
-  with_items: [ 'libvirt-bin', 'netcat-openbsd', 'gawk', 'qemu-system', 'qemu-utils', 'pm-utils', 'ebtables', 'qemu-kvm' ]
+  with_items:
+    - 'libvirt-bin'
+    - 'netcat-openbsd'
+    - 'gawk'
+    - 'qemu-system'
+    - 'qemu-utils'
+    - 'pm-utils'
+    - 'ebtables'
+    - 'qemu-kvm'
 
 - name: Add administrators to libvirt group
   user:


### PR DESCRIPTION
qemu-utils is needed to create non-raw images, like qcow2 which is virt-manager's default image type.